### PR TITLE
Only try to format log message if args are of correct type and length

### DIFF
--- a/enochecker3/logging.py
+++ b/enochecker3/logging.py
@@ -9,7 +9,7 @@ LOGGING_PREFIX = "##ENOLOGMESSAGE "
 
 class ELKFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
-        if record.args is not None:
+        if type(record.args) is tuple and len(record.args) > 0:
             record.msg = record.msg % record.args
 
         return LOGGING_PREFIX + self.create_message(record).json(by_alias=True)


### PR DESCRIPTION
https://docs.python.org/3/library/logging.html#logging.LogRecord

LogRecord args can be either tuple or dict.. need to check length as well