### PR TITLE
make any exception in async socket's open_connection result in OFFLINE

### DIFF
--- a/enochecker3/enochecker.py
+++ b/enochecker3/enochecker.py
@@ -401,7 +401,7 @@ class Enochecker:
             conn = await asyncio.streams.open_connection(
                 task.address, self.service_port
             )
-        except (ConnectionError, asyncio.TimeoutError):
+        except:
             trace = traceback.format_exc()
             logger.info(f"Failed to connect to service\n{trace}")
             raise OfflineException("Could not establish socket connection to service")


### PR DESCRIPTION
exception backtrace is logged anyways.. if the connection fails this should never be the checkers fault (which an unhandled exception implies)